### PR TITLE
feat: 댓글 수 제한 로직 구현과 동시성 제어 및 안정성 개선

### DIFF
--- a/src/main/java/com/eeum/domain/comment/entity/Comment.java
+++ b/src/main/java/com/eeum/domain/comment/entity/Comment.java
@@ -43,10 +43,6 @@ public class Comment {
         this.content = content;
     }
 
-    public void delete() {
-        this.isDeleted = true;
-    }
-
     public static Comment of(String content, Long postId, Long userId, String username, String artworkUrl) {
         LocalDateTime now = LocalDateTime.now();
         return Comment.builder()

--- a/src/main/java/com/eeum/domain/comment/entity/CommentCount.java
+++ b/src/main/java/com/eeum/domain/comment/entity/CommentCount.java
@@ -1,0 +1,25 @@
+package com.eeum.domain.comment.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.*;
+
+@Table(name = "comment_count")
+@Entity
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentCount {
+
+    @Id
+    private Long postId;
+    private Long commentCount;
+
+    public static CommentCount of(Long postId, Long count) {
+        CommentCount commentCount = new CommentCount();
+        commentCount.postId = postId;
+        commentCount.commentCount = count;
+        return commentCount;
+    }
+}

--- a/src/main/java/com/eeum/domain/comment/entity/CommentCount.java
+++ b/src/main/java/com/eeum/domain/comment/entity/CommentCount.java
@@ -15,11 +15,13 @@ public class CommentCount {
     @Id
     private Long postId;
     private Long commentCount;
+    private Long commentCountLimit;
 
-    public static CommentCount of(Long postId, Long count) {
+    public static CommentCount of(Long postId, Long count, Long commentCountLimit) {
         CommentCount commentCount = new CommentCount();
         commentCount.postId = postId;
         commentCount.commentCount = count;
+        commentCount.commentCountLimit = commentCountLimit;
         return commentCount;
     }
 }

--- a/src/main/java/com/eeum/domain/comment/exception/AlreadyFinishedPostException.java
+++ b/src/main/java/com/eeum/domain/comment/exception/AlreadyFinishedPostException.java
@@ -1,0 +1,7 @@
+package com.eeum.domain.comment.exception;
+
+public class AlreadyFinishedPostException extends RuntimeException {
+    public AlreadyFinishedPostException(String reason) {
+        super(reason);
+    }
+}

--- a/src/main/java/com/eeum/domain/comment/repository/CommentCountRepository.java
+++ b/src/main/java/com/eeum/domain/comment/repository/CommentCountRepository.java
@@ -1,10 +1,14 @@
 package com.eeum.domain.comment.repository;
 
 import com.eeum.domain.comment.entity.CommentCount;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface CommentCountRepository extends JpaRepository<CommentCount, Long> {
 
@@ -21,4 +25,7 @@ public interface CommentCountRepository extends JpaRepository<CommentCount, Long
     )
     @Modifying
     int decrease(@Param("postId") Long postId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<CommentCount> findLockedByPostId(Long aLong);
 }

--- a/src/main/java/com/eeum/domain/comment/repository/CommentCountRepository.java
+++ b/src/main/java/com/eeum/domain/comment/repository/CommentCountRepository.java
@@ -1,0 +1,24 @@
+package com.eeum.domain.comment.repository;
+
+import com.eeum.domain.comment.entity.CommentCount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CommentCountRepository extends JpaRepository<CommentCount, Long> {
+
+    @Query(
+            value = "update comment_count set comment_count = comment_count + 1 where post_id = :postId",
+            nativeQuery = true
+    )
+    @Modifying
+    int increase(@Param("postId") Long postId);
+
+    @Query(
+            value = "update comment_count set comment_count = comment_count - 1 where post_id = :postId",
+            nativeQuery = true
+    )
+    @Modifying
+    int decrease(@Param("postId") Long postId);
+}

--- a/src/main/java/com/eeum/domain/comment/service/CommentService.java
+++ b/src/main/java/com/eeum/domain/comment/service/CommentService.java
@@ -4,10 +4,14 @@ import com.eeum.domain.comment.dto.request.CommentCreateRequest;
 import com.eeum.domain.comment.dto.response.CommentResponse;
 import com.eeum.domain.comment.entity.Comment;
 import com.eeum.domain.comment.entity.CommentCount;
+import com.eeum.domain.comment.exception.AlreadyFinishedPostException;
 import com.eeum.domain.comment.repository.CommentCountRepository;
 import com.eeum.domain.comment.repository.CommentRepository;
+import com.eeum.domain.posts.entity.Posts;
+import com.eeum.domain.posts.repository.PostsRepository;
 import com.eeum.global.securitycore.token.UserPrincipal;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,30 +21,30 @@ import java.util.Optional;
 
 import static java.util.function.Predicate.*;
 
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class CommentService {
     private final CommentRepository commentRepository;
     private final CommentCountRepository commentCountRepository;
+    private final PostsRepository postsRepository;
 
     @Transactional
     public CommentResponse create(UserPrincipal userPrincipal, CommentCreateRequest request) {
-        Comment comment = Comment.of(
-                request.content(),
-                request.postId(),
-                userPrincipal.getId(),
-                userPrincipal.getUsername(),
-                request.artworkUrl()
-        );
+        CommentCount commentCount = commentCountRepository.findLockedByPostId(request.postId())
+                .orElseThrow(() -> new IllegalArgumentException("Can't find CommentCount Entity."));
+        Posts postForValidate = postsRepository.findById(request.postId())
+                .orElseThrow(() -> new IllegalArgumentException("Can't find Post Entity."));
+
+        validatePostAvailableStatus(commentCount, postForValidate);
+
+        Comment comment = createComment(userPrincipal, request);
         commentRepository.save(comment);
 
-        int result = commentCountRepository.increase(request.postId());
-        if (result == 0) {
-            commentCountRepository.save(
-                    CommentCount.of(request.postId(), 1L)
-            );
-        }
+        commentCountRepository.increase(request.postId());
+
+        validateAndUpdatePostCompleteStatus(request, commentCount);
 
         return CommentResponse.from(comment);
     }
@@ -56,8 +60,38 @@ public class CommentService {
         Optional<Comment> comment = commentRepository.findByIdAndUserId(userId, commentId)
                 .filter(not(Comment::getIsDeleted));
         if (comment.isPresent()) {
-            comment.get().delete();
+            commentRepository.delete(comment.get());
+
+            CommentCount commentCount = commentCountRepository.findLockedByPostId(comment.get().getPostId())
+                    .orElseThrow(() -> new RuntimeException("Can't find CommentCount Entity."));
             commentCountRepository.decrease(comment.get().getPostId());
+        }
+    }
+
+    private void validateAndUpdatePostCompleteStatus(CommentCreateRequest request, CommentCount commentCount) {
+        if ((Long.valueOf(commentCount.getCommentCount() + 1)).equals(commentCount.getCommentCountLimit())) {
+            Posts posts = postsRepository.findById(request.postId())
+                    .orElseThrow(() -> new IllegalArgumentException("That post is not founded."));
+            posts.updateIsCompleted();
+        }
+    }
+
+    private static Comment createComment(UserPrincipal userPrincipal, CommentCreateRequest request) {
+        return Comment.of(
+                request.content(),
+                request.postId(),
+                userPrincipal.getId(),
+                userPrincipal.getUsername(),
+                request.artworkUrl()
+        );
+    }
+
+    private static void validatePostAvailableStatus(CommentCount commentCount, Posts postForValidate) {
+        if (commentCount.getCommentCount() >= commentCount.getCommentCountLimit()) {
+            throw new AlreadyFinishedPostException("comment_limit_reached.");
+        }
+        if (postForValidate.getIsCompleted()) {
+            throw new AlreadyFinishedPostException("post_completed.");
         }
     }
 }

--- a/src/main/java/com/eeum/domain/comment/service/CommentService.java
+++ b/src/main/java/com/eeum/domain/comment/service/CommentService.java
@@ -3,6 +3,8 @@ package com.eeum.domain.comment.service;
 import com.eeum.domain.comment.dto.request.CommentCreateRequest;
 import com.eeum.domain.comment.dto.response.CommentResponse;
 import com.eeum.domain.comment.entity.Comment;
+import com.eeum.domain.comment.entity.CommentCount;
+import com.eeum.domain.comment.repository.CommentCountRepository;
 import com.eeum.domain.comment.repository.CommentRepository;
 import com.eeum.global.securitycore.token.UserPrincipal;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.function.Predicate.*;
 
@@ -19,6 +22,7 @@ import static java.util.function.Predicate.*;
 @RequiredArgsConstructor
 public class CommentService {
     private final CommentRepository commentRepository;
+    private final CommentCountRepository commentCountRepository;
 
     @Transactional
     public CommentResponse create(UserPrincipal userPrincipal, CommentCreateRequest request) {
@@ -30,6 +34,14 @@ public class CommentService {
                 request.artworkUrl()
         );
         commentRepository.save(comment);
+
+        int result = commentCountRepository.increase(request.postId());
+        if (result == 0) {
+            commentCountRepository.save(
+                    CommentCount.of(request.postId(), 1L)
+            );
+        }
+
         return CommentResponse.from(comment);
     }
 
@@ -41,8 +53,11 @@ public class CommentService {
 
     @Transactional
     public void delete(Long userId, Long commentId) {
-        commentRepository.findByIdAndUserId(userId, commentId)
-                .filter(not(Comment::getIsDeleted))
-                .ifPresent(Comment::delete);
+        Optional<Comment> comment = commentRepository.findByIdAndUserId(userId, commentId)
+                .filter(not(Comment::getIsDeleted));
+        if (comment.isPresent()) {
+            comment.get().delete();
+            commentCountRepository.decrease(comment.get().getPostId());
+        }
     }
 }

--- a/src/main/java/com/eeum/domain/posts/controller/PostsController.java
+++ b/src/main/java/com/eeum/domain/posts/controller/PostsController.java
@@ -32,7 +32,7 @@ public class PostsController {
     public ApiResponse<UpdatePostResponse> updatePost(
             @CurrentUser UserPrincipal userPrincipal,
             @RequestBody UpdatePostRequest updatePostRequest
-            ) {
+    ) {
         return ApiResponse.success(postsService.updatePost(userPrincipal.getId(), updatePostRequest));
     }
 
@@ -86,5 +86,12 @@ public class PostsController {
             @CurrentUser UserPrincipal userPrincipal
     ) {
         return ApiResponse.success(postsService.getLikedPosts(userPrincipal.getId()));
+    }
+
+    @GetMapping("/commented")
+    public ApiResponse<List<GetCommentedPostsResponse>> getCommentedPosts(
+            @CurrentUser UserPrincipal userPrincipal
+    ) {
+        return ApiResponse.success(postsService.getCommentedPosts(userPrincipal.getId()));
     }
 }

--- a/src/main/java/com/eeum/domain/posts/dto/request/CreatePostRequest.java
+++ b/src/main/java/com/eeum/domain/posts/dto/request/CreatePostRequest.java
@@ -1,5 +1,6 @@
 package com.eeum.domain.posts.dto.request;
 
+import com.eeum.domain.posts.entity.CompletionType;
 import jakarta.validation.constraints.NotNull;
 
 public record CreatePostRequest(
@@ -10,6 +11,7 @@ public record CreatePostRequest(
         String songName,
         String artistName,
         String artworkUrl,
-        String appleMusicUrl
+        String appleMusicUrl,
+        CompletionType completionType
 ) {
 }

--- a/src/main/java/com/eeum/domain/posts/dto/request/CreatePostRequest.java
+++ b/src/main/java/com/eeum/domain/posts/dto/request/CreatePostRequest.java
@@ -12,6 +12,7 @@ public record CreatePostRequest(
         String artistName,
         String artworkUrl,
         String appleMusicUrl,
-        CompletionType completionType
+        CompletionType completionType,
+        Long commentCountLimit
 ) {
 }

--- a/src/main/java/com/eeum/domain/posts/dto/response/GetCommentedPostsResponse.java
+++ b/src/main/java/com/eeum/domain/posts/dto/response/GetCommentedPostsResponse.java
@@ -1,0 +1,18 @@
+package com.eeum.domain.posts.dto.response;
+
+import com.eeum.domain.posts.entity.Posts;
+
+import java.time.LocalDateTime;
+
+public record GetCommentedPostsResponse(
+        Long postId,
+        String artworkUrl,
+        String title,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static GetCommentedPostsResponse from(Posts posts) {
+        return new GetCommentedPostsResponse(posts.getId(), posts.getAlbum().getArtworkUrl(), posts.getTitle(),
+                posts.getCreatedAt(), posts.getUpdatedAt());
+    }
+}

--- a/src/main/java/com/eeum/domain/posts/dto/response/PostsReadInfiniteScrollResponse.java
+++ b/src/main/java/com/eeum/domain/posts/dto/response/PostsReadInfiniteScrollResponse.java
@@ -12,7 +12,8 @@ public record PostsReadInfiniteScrollResponse(
         String artistName,
         String artworkUrl,
         String appleMusicUrl,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        boolean isCompleted
 ) {
 
     public static PostsReadInfiniteScrollResponse from(PostsQueryModel postsQueryModel) {
@@ -24,7 +25,8 @@ public record PostsReadInfiniteScrollResponse(
                 postsQueryModel.getArtistName(),
                 postsQueryModel.getArtworkUrl(),
                 postsQueryModel.getAppleMusicUrl(),
-                postsQueryModel.getCreatedAt()
+                postsQueryModel.getCreatedAt(),
+                postsQueryModel.isCompleted()
         );
     }
 }

--- a/src/main/java/com/eeum/domain/posts/entity/CompletionType.java
+++ b/src/main/java/com/eeum/domain/posts/entity/CompletionType.java
@@ -1,0 +1,5 @@
+package com.eeum.domain.posts.entity;
+
+public enum CompletionType {
+    AUTO_COMPLETION, MANUAL_COMPLETION
+}

--- a/src/main/java/com/eeum/domain/posts/entity/Posts.java
+++ b/src/main/java/com/eeum/domain/posts/entity/Posts.java
@@ -1,10 +1,7 @@
 package com.eeum.domain.posts.entity;
 
 import io.hypersistence.utils.hibernate.id.Tsid;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
@@ -38,6 +35,9 @@ public class Posts {
 
     private Boolean isCompleted;
 
+    @Enumerated(EnumType.STRING)
+    private CompletionType completionType;
+
     public void update(String title, String content) {
         this.title = title;
         this.content = content;
@@ -46,6 +46,10 @@ public class Posts {
 
     public void updateIsCompleted() {
         this.isCompleted = Boolean.TRUE;
+    }
+
+    public void updateCompletionType(CompletionType completionType) {
+        this.completionType = completionType;
     }
 
     public static Posts of(String title, String content, Album album, Long userId) {

--- a/src/main/java/com/eeum/domain/posts/repository/PostsQueryModel.java
+++ b/src/main/java/com/eeum/domain/posts/repository/PostsQueryModel.java
@@ -17,6 +17,7 @@ public class PostsQueryModel {
     private String appleMusicUrl;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    private boolean isCompleted;
 
 
     public static PostsQueryModel create(Posts posts) {
@@ -31,6 +32,7 @@ public class PostsQueryModel {
         postsQueryModel.appleMusicUrl = posts.getAlbum().getAppleMusicUrl();
         postsQueryModel.createdAt = posts.getCreatedAt();
         postsQueryModel.updatedAt = posts.getUpdatedAt();
+        postsQueryModel.isCompleted = posts.getIsCompleted();
         return postsQueryModel;
     }
 
@@ -44,7 +46,8 @@ public class PostsQueryModel {
             String artworkUrl,
             String appleMusicUrl,
             LocalDateTime createdAt,
-            LocalDateTime updatedAt) {
+            LocalDateTime updatedAt,
+            boolean isCompleted) {
         PostsQueryModel postsQueryModel = new PostsQueryModel();
         postsQueryModel.postId = postId;
         postsQueryModel.title = title;
@@ -56,6 +59,7 @@ public class PostsQueryModel {
         postsQueryModel.appleMusicUrl = appleMusicUrl;
         postsQueryModel.createdAt = createdAt;
         postsQueryModel.updatedAt = updatedAt;
+        postsQueryModel.isCompleted = isCompleted;
         return postsQueryModel;
     }
 }

--- a/src/main/java/com/eeum/domain/posts/repository/PostsRepository.java
+++ b/src/main/java/com/eeum/domain/posts/repository/PostsRepository.java
@@ -49,9 +49,20 @@ public interface PostsRepository extends JpaRepository<Posts, Long> {
                     "from posts p " +
                     "left join likes l on p.id = l.post_id " +
                     "where l.user_id = :userId " +
-                    "and (p.is_deleted = false or p.is_deleted = null) " +
+                    "and p.is_deleted = false " +
                     "order by p.created_at desc",
             nativeQuery = true
     )
     List<Posts> findPostsLikedByUserId(@Param("userId") Long userId);
+
+    @Query(
+            value = "select distinct p.* " +
+                    "from posts p " +
+                    "left join comments c on p.id = c.post_id " +
+                    "where c.user_id = :userId " +
+                    "and p.is_deleted = false " +
+                    "order by p.created_at desc",
+            nativeQuery = true
+    )
+    List<Posts> findPostsCommentedByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/eeum/domain/posts/service/PostsService.java
+++ b/src/main/java/com/eeum/domain/posts/service/PostsService.java
@@ -119,9 +119,14 @@ public class PostsService {
     public List<GetLikedPostsResponse> getLikedPosts(Long userId) {
         List<Posts> posts = postsRepository.findPostsLikedByUserId(userId);
 
-        log.info(posts.toString());
-
         List<GetLikedPostsResponse> response = posts.stream().map(GetLikedPostsResponse::from).toList();
+        return response;
+    }
+
+    public List<GetCommentedPostsResponse> getCommentedPosts(Long userId) {
+        List<Posts> posts = postsRepository.findPostsCommentedByUserId(userId);
+
+        List<GetCommentedPostsResponse> response = posts.stream().map(GetCommentedPostsResponse::from).toList();
         return response;
     }
 

--- a/src/main/java/com/eeum/domain/posts/service/PostsService.java
+++ b/src/main/java/com/eeum/domain/posts/service/PostsService.java
@@ -38,6 +38,7 @@ public class PostsService {
     public CreatePostResponse createPost(Long userId, CreatePostRequest createPostRequest) {
         Album album = Album.of(createPostRequest.albumName(), createPostRequest.songName(), createPostRequest.artistName(), createPostRequest.artworkUrl(), createPostRequest.appleMusicUrl());
         Posts posts = Posts.of(createPostRequest.title(), createPostRequest.content(), album, userId);
+        posts.updateCompletionType(createPostRequest.completionType());
         postsRepository.save(posts);
 
         return CreatePostResponse.of(posts.getId(), userId);

--- a/src/main/java/com/eeum/global/support/error/ApiControllerAdvice.java
+++ b/src/main/java/com/eeum/global/support/error/ApiControllerAdvice.java
@@ -1,5 +1,6 @@
 package com.eeum.global.support.error;
 
+import com.eeum.domain.comment.exception.AlreadyFinishedPostException;
 import com.eeum.global.support.error.exception.CoreApiException;
 import com.eeum.global.support.response.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -41,5 +42,13 @@ public class ApiControllerAdvice {
 
         log.debug("Invalid Request: {}", errorMessage);
         return new ResponseEntity<>(ApiResponse.error(ErrorType.VALIDATION_ERROR, e.getMessage()), HttpStatusCode.valueOf(ErrorType.VALIDATION_ERROR.getStatusCode()));
+    }
+
+    @ExceptionHandler(AlreadyFinishedPostException.class)
+    public ResponseEntity<ApiResponse<?>> handleAlreadyFinishedPostException(
+        AlreadyFinishedPostException e
+    ) {
+        log.info("AlreadyFinishedPostException 발생: {}", e.getMessage());
+        return new ResponseEntity<>(ApiResponse.error(ErrorType.ALREADY_FINISHED_POST, e.getMessage()), HttpStatusCode.valueOf(ErrorType.ALREADY_FINISHED_POST.getStatusCode()));
     }
 }

--- a/src/main/java/com/eeum/global/support/error/ErrorCode.java
+++ b/src/main/java/com/eeum/global/support/error/ErrorCode.java
@@ -10,7 +10,8 @@ public enum ErrorCode {
     FORBIDDEN_403,              // 403: 권한 없음
     NOT_FOUND_404,              // 404: 리소스를 찾을 수 없음
     CONFLICT_409,               // 409: 데이터 충돌
-    VALIDATION_ERROR_422;        // 422: 유효성 검사 실패
+    VALIDATION_ERROR_422,  // 422: 유효성 검사 실패
+    POST_409;
 
 
     private String message;

--- a/src/main/java/com/eeum/global/support/error/ErrorType.java
+++ b/src/main/java/com/eeum/global/support/error/ErrorType.java
@@ -45,6 +45,12 @@ public enum ErrorType {
             422,
             ErrorCode.VALIDATION_ERROR_422,
             "The request contains invalid data or parameters."
+    ),
+
+    ALREADY_FINISHED_POST(
+            409,
+            ErrorCode.POST_409,
+            "This post's status is already finished."
     );
 
     private final int statusCode;


### PR DESCRIPTION
## ✨ 작업 개요
- 댓글 작성 시 동시에 여러 사용자가 접근하는 경우를 대비해, 댓글 수 제한 로직에 비관적 락을 적용하여 동시성 문제를 방지했습니다.
- 게시글 완료 상태 및 댓글 수 제한 조건을 충족하는 경우, 예외를 통해 추가 댓글 작성이 불가능하도록 제어하고 로그를 남겼습니다.

## 📈 성능 변화
- 평균 응답 시간: 기존과 동일 (비관적 락 범위를 최소화하여 성능 저하 없음)

## 🔧 주요 변경사항
- `CommentCountRepository`의 `findLockedByPostId()`에 `@Lock(PESSIMISTIC_WRITE)` 적용
- 댓글 작성 시 `CommentCount`에 대한 락 선점으로 동시성 제어 구현
- 댓글 수 제한 조건 또는 게시글 완료 상태에 따른 예외 처리 로직 도입
- `AlreadyFinishedPostException` 추가 및 `ApiControllerAdvice`에서 예외 핸들러 정의
- 예외 발생 시 실패 사유에 대한 상세 로깅 추가

## ✅ 기타
- 운영 환경에서 다수 사용자의 동시 댓글 요청 시에도 정합성을 보장할 수 있도록 개선된 로직입니다.